### PR TITLE
Add ISO 3166-1:2020 + Unicode 13.0.0 support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Jason Jacob
+Copyright (c) 2019-2021 Jason Jacob & Joshua O'Sullivan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -285,3 +285,7 @@ func main() {
  CUW/CW - 🇨🇼
  BES/BQ - 🇧🇶
 ```
+
+## BES/BQ Note
+
+The flag of Bonaire, Sint Eustatius and Saba (country codes BES & BQ) may render as the flag of the Netherlands on some devices as of 11/04/2021.

--- a/README.md
+++ b/README.md
@@ -281,4 +281,5 @@ func main() {
  NCL/NC - 🇳🇨
  NFK/NF - 🇳🇫
  SOM/SO - 🇸🇴
+ XKX/XK - 🇽🇰
 ```

--- a/README.md
+++ b/README.md
@@ -283,4 +283,5 @@ func main() {
  SOM/SO - 🇸🇴
  XKX/XK - 🇽🇰
  CUW/CW - 🇨🇼
+ BES/BQ - 🇧🇶
 ```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Converts a string country code to an emoji in Go.
 
+Supports the country codes of [ISO 3166-1:2020 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) and [ISO 3166-1:2020 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) where Unicode 13.0.0 has apropriate emoji flags available.
+
 ## Install
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Converts a string country code to an emoji in Go.
 
-Supports the country codes of [ISO 3166-1:2020 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) and [ISO 3166-1:2020 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) where Unicode 13.0.0 has apropriate emoji flags available.
+Supports the country codes of [ISO 3166-1:2020 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) and [ISO 3166-1:2020 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) where Unicode 13.0.0 has appropriate emoji flags available.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -282,4 +282,5 @@ func main() {
  NFK/NF - 🇳🇫
  SOM/SO - 🇸🇴
  XKX/XK - 🇽🇰
+ CUW/CW - 🇨🇼
 ```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # go-emoji-flag
 
-[![CircleCI](https://circleci.com/gh/jayco/go-emoji-flag.svg?style=svg)](https://circleci.com/gh/jayco/go-emoji-flag)
-[![GolangCI](https://golangci.com/badges/github.com/jayco/go-emoji-flag.svg)](https://golangci.com)
-[![Go Report Card](https://goreportcard.com/badge/github.com/jayco/go-emoji-flag)](https://golangci.com)
-
 Converts a string country code to an emoji in Go.
 
 Supports the country codes of [ISO 3166-1:2020 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) and [ISO 3166-1:2020 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) where Unicode 13.0.0 has apropriate emoji flags available.

--- a/emoji_flag.go
+++ b/emoji_flag.go
@@ -253,6 +253,7 @@ var countryMap = map[string]string{
 	"ZMB": "ZM",
 	"ZWE": "ZW",
 	"XKX": "XK",
+	"CUW": "CW",
 }
 
 // GetFlag returns a best attempt at matching a country code flag

--- a/emoji_flag.go
+++ b/emoji_flag.go
@@ -254,6 +254,7 @@ var countryMap = map[string]string{
 	"ZWE": "ZW",
 	"XKX": "XK",
 	"CUW": "CW",
+	"BES": "BQ",
 }
 
 // GetFlag returns a best attempt at matching a country code flag

--- a/emoji_flag.go
+++ b/emoji_flag.go
@@ -252,6 +252,7 @@ var countryMap = map[string]string{
 	"YEM": "YE",
 	"ZMB": "ZM",
 	"ZWE": "ZW",
+	"XKX": "XK",
 }
 
 // GetFlag returns a best attempt at matching a country code flag


### PR DESCRIPTION
Add support for the country codes of [ISO 3166-1:2020 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) and [ISO 3166-1:2020 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) where Unicode 13.0.0 has appropriate emoji flags available.

Incomplete but making this PR early.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three new country-code mappings to the `countryMap` in `emoji_flag.go`: Kosovo (`XKX`→`XK`), Curaçao (`CUW`→`CW`), and Bonaire, Sint Eustatius and Saba (`BES`→`BQ`). The author acknowledges the PR is incomplete. The `GetFlag` logic correctly handles all new entries — the regional indicator arithmetic works for all three alpha-2 codes.

- `emoji_flag.go`: Three map entries appended; the existing `GetFlag` function handles them correctly for both 3-char and 2-char lookup paths.
- `README.md`: CI badges removed without explanation, description updated to mention ISO 3166-1:2020, and example output extended with the new codes.
- `LICENSE`: Copyright year and co-author updated.

<h3>Confidence Score: 4/5</h3>

The mapping additions are correct and the existing GetFlag logic handles all new entries without modification; the change is safe to merge.

The three new map entries are data-only changes that work correctly with the existing function. The main gaps are missing test coverage for the new entries and a mismatch between the PR's ISO 3166-1:2020 framing and the XKX/XK codes, which are user-assigned rather than official ISO codes. Neither issue causes incorrect runtime behavior.

emoji_flag.go — no tests cover the three new mappings; a typo in any value would go undetected by the current test suite.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| emoji_flag.go | Adds three new alpha-3→alpha-2 mappings (XKX→XK, CUW→CW, BES→BQ); logic is correct but no tests were added for the new entries, and XKX/XK are user-assigned codes rather than official ISO 3166-1:2020 codes as the PR claims. |
| README.md | Removes three CI/CD badge links without explanation, updates the description to mention ISO 3166-1:2020 support, and adds example output and a note about the BES/BQ flag rendering caveat. |
| LICENSE | Updates copyright year range to 2019–2021 and adds co-author Joshua O'Sullivan; no issues. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GetFlag input] --> B{len == 3?}
    B -- Yes --> C{countryMap lookup}
    C -- Found --> D[Build emoji from alpha-2 value]
    C -- Not found --> E{len == 2?}
    B -- No --> E
    E -- Yes --> F[Linear scan of countryMap values]
    F --> G{Match found?}
    G -- Yes --> H[Build emoji from input directly]
    G -- No --> I[Return empty string]
    D --> J[Return emoji string]
    H --> J

    subgraph New entries
        N1["XKX → XK (Kosovo)"]
        N2["CUW → CW (Curaçao)"]
        N3["BES → BQ (Bonaire etc.)"]
    end

    C -.uses.-> N1
    C -.uses.-> N2
    C -.uses.-> N3
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[GetFlag input] --> B{len == 3?}
    B -- Yes --> C{countryMap lookup}
    C -- Found --> D[Build emoji from alpha-2 value]
    C -- Not found --> E{len == 2?}
    B -- No --> E
    E -- Yes --> F[Linear scan of countryMap values]
    F --> G{Match found?}
    G -- Yes --> H[Build emoji from input directly]
    G -- No --> I[Return empty string]
    D --> J[Return emoji string]
    H --> J

    subgraph New entries
        N1["XKX → XK (Kosovo)"]
        N2["CUW → CW (Curaçao)"]
        N3["BES → BQ (Bonaire etc.)"]
    end

    C -.uses.-> N1
    C -.uses.-> N2
    C -.uses.-> N3
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aemoji_flag.go%3A255-257%0A**No%20tests%20for%20newly%20added%20country%20codes**%0A%0AThe%20test%20file%20only%20covers%20%60AUS%60%2F%60AU%60%20as%20representative%20inputs.%20None%20of%20the%20three%20new%20entries%20%28%60XKX%60%2F%60XK%60%2C%20%60CUW%60%2F%60CW%60%2C%20%60BES%60%2F%60BQ%60%29%20have%20test%20cases%2C%20so%20a%20typo%20in%20any%20mapping%20would%20go%20undetected.%20For%20instance%2C%20the%20%60BES%20%E2%86%92%20BQ%60%20mapping%20could%20silently%20produce%20an%20incorrect%20flag%20if%20the%20value%20were%20accidentally%20transposed%20%E2%80%94%20the%20existing%20test%20suite%20wouldn't%20catch%20it.%0A%0A%23%23%23%20Issue%202%20of%203%0Aemoji_flag.go%3A255%0A**XKX%2FXK%20are%20user-assigned%20codes%2C%20not%20ISO%203166-1%20entries**%0A%0A%60XKX%60%20%28Kosovo%20alpha-3%29%20and%20%60XK%60%20%28Kosovo%20alpha-2%29%20are%20user-assigned%20reservation%20codes%20adopted%20by%20the%20EU%20and%20other%20organizations%20but%20are%20explicitly%20**not**%20part%20of%20ISO%203166-1%3A2020.%20The%20PR%20description%20and%20README%20both%20advertise%20this%20change%20as%20%22ISO%203166-1%3A2020%20alpha-2%2Falpha-3%20support%22%2C%20which%20is%20inaccurate%20for%20this%20entry.%20Including%20Kosovo%20is%20pragmatically%20reasonable%2C%20but%20the%20documentation%20should%20clarify%20it%20as%20a%20user-assigned%20extension%20rather%20than%20an%20ISO%20code.%0A%0A%23%23%23%20Issue%203%20of%203%0AREADME.md%3A1-9%0A**CI%20badge%20removal%20is%20unexplained**%0A%0AThe%20CircleCI%2C%20GolangCI%2C%20and%20Go%20Report%20Card%20badges%20were%20removed%20without%20any%20explanation%20in%20the%20PR%20description.%20If%20the%20pipelines%20are%20broken%20or%20the%20services%20are%20no%20longer%20in%20use%2C%20that%20context%20would%20help%20reviewers%20understand%20the%20intent.%20If%20they%20are%20still%20active%2C%20removing%20them%20reduces%20visibility%20into%20build%20and%20lint%20health%20for%20contributors.%0A%0A&repo=jayco%2Fgo-emoji-flag&pr=1&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
emoji_flag.go:255-257
**No tests for newly added country codes**

The test file only covers `AUS`/`AU` as representative inputs. None of the three new entries (`XKX`/`XK`, `CUW`/`CW`, `BES`/`BQ`) have test cases, so a typo in any mapping would go undetected. For instance, the `BES → BQ` mapping could silently produce an incorrect flag if the value were accidentally transposed — the existing test suite wouldn't catch it.

### Issue 2 of 3
emoji_flag.go:255
**XKX/XK are user-assigned codes, not ISO 3166-1 entries**

`XKX` (Kosovo alpha-3) and `XK` (Kosovo alpha-2) are user-assigned reservation codes adopted by the EU and other organizations but are explicitly **not** part of ISO 3166-1:2020. The PR description and README both advertise this change as "ISO 3166-1:2020 alpha-2/alpha-3 support", which is inaccurate for this entry. Including Kosovo is pragmatically reasonable, but the documentation should clarify it as a user-assigned extension rather than an ISO code.

### Issue 3 of 3
README.md:1-9
**CI badge removal is unexplained**

The CircleCI, GolangCI, and Go Report Card badges were removed without any explanation in the PR description. If the pipelines are broken or the services are no longer in use, that context would help reviewers understand the intent. If they are still active, removing them reduces visibility into build and lint health for contributors.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix typo"](https://github.com/jayco/go-emoji-flag/commit/1457817623e8cc9591bce056258eb78c02735ede) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44314813)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->